### PR TITLE
Adjust base font size to 16pt

### DIFF
--- a/src/styles/core.scss
+++ b/src/styles/core.scss
@@ -20,7 +20,7 @@
 @import './components.scss';
 
 html {
-  font-size: 18px;
+  font-size: 16px;
 }
 
 $display-types: (


### PR DESCRIPTION
This changes the rem size from 18pt to 16pt. 16pt is the default font
size, so using this will reduce inconsistencies between sapling styles.
It is also the size used in most Canopy/sapling mockups currently.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>