### PR TITLE
Add app config to canopy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,16 +7,22 @@
   "parserOptions": {
     "ecmaVersion": 2020
   },
-  "extends": ["airbnb", "plugin:prettier/recommended"],
+  "extends": [
+    "airbnb",
+    "plugin:prettier/recommended"
+  ],
   "rules": {
     "react/jsx-filename-extension": 0,
     "react/prefer-stateless-function": 0,
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": 0,
+    "react/forbid-prop-types": 0
   },
   "settings": {
     "import/resolver": {
       "node": {
-        "paths": ["src"]
+        "paths": [
+          "src"
+        ]
       }
     }
   }

--- a/src/CanopyContext.js
+++ b/src/CanopyContext.js
@@ -38,7 +38,12 @@ const fetchConfigSaplings = async saplingURL => {
   return configSaplingsResponse;
 };
 
-export function CanopyProvider({ saplingURL, splinterURL, children }) {
+export function CanopyProvider({
+  saplingURL,
+  splinterURL,
+  appConfig,
+  children
+}) {
   const [userSaplings, setUserSaplings] = useState([]);
   const [configSaplings, setConfigSaplings] = useState({});
 
@@ -57,7 +62,8 @@ export function CanopyProvider({ saplingURL, splinterURL, children }) {
       canopyConfig: {
         splinterURL,
         saplingURL
-      }
+      },
+      appConfig
     };
   };
 
@@ -110,15 +116,22 @@ export function CanopyProvider({ saplingURL, splinterURL, children }) {
   }, [saplingURL]);
 
   return (
-    <CanopyContext.Provider value={{ configSaplings, userSaplings, user, keys }}>
+    <CanopyContext.Provider
+      value={{ configSaplings, userSaplings, user, keys }}
+    >
       {children}
     </CanopyContext.Provider>
   );
 }
 
+CanopyProvider.defaultProps = {
+  appConfig: {}
+};
+
 CanopyProvider.propTypes = {
   saplingURL: PropTypes.string.isRequired,
   splinterURL: PropTypes.string.isRequired,
+  appConfig: PropTypes.object,
   children: PropTypes.node.isRequired
 };
 


### PR DESCRIPTION
This PR allows us to send arbitrary config to saplings from the Canopy app. For example, we can pass in the Grid Daemon URL in the Grid UI so that it is available across saplings.