### PR TITLE
Redirect users to login sapling if they are not logged in

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "classnames": "^2.2.6",
+    "history": "^4.10.1",
     "prop-types": "^15.7.2",
     "webpack": "^4.41.5"
   },

--- a/src/CanopyContext.js
+++ b/src/CanopyContext.js
@@ -16,6 +16,7 @@
 
 import React, { useState, createContext, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { createBrowserHistory } from 'history';
 
 import { get } from './request';
 import {
@@ -25,6 +26,7 @@ import {
 } from './loadSaplings';
 
 export const CanopyContext = createContext({});
+const history = createBrowserHistory();
 
 const fetchUserSaplings = async saplingURL => {
   const response = await get(`${saplingURL}/userSaplings`);
@@ -108,11 +110,17 @@ export function CanopyProvider({
   }, []);
 
   useEffect(() => {
-    fetchUserSaplings(saplingURL).then(saplings => {
-      mountSaplingStyles(saplings);
-      mountCurrentSapling(saplings);
-      setUserSaplings(saplings);
-    });
+    if (sessionUser) {
+      fetchUserSaplings(saplingURL).then(saplings => {
+        mountSaplingStyles(saplings);
+        mountCurrentSapling(saplings);
+        setUserSaplings(saplings);
+      });
+    } else {
+      window.$CANOPY.hideCanopy();
+      window.$CANOPY.redirectedFrom = window.location.href;
+      history.push('/login');
+    }
   }, [saplingURL]);
 
   return (


### PR DESCRIPTION
The sideEffect that loads user saplings now checks if that user is
logged in and will redirect the user to a login sapling if they are not
logged in.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>