### PR TITLE
Fix sapling tab rendering on refresh

### DIFF
--- a/src/CanopyContext.js
+++ b/src/CanopyContext.js
@@ -46,8 +46,17 @@ export function CanopyProvider({
   appConfig,
   children
 }) {
-  const [userSaplings, setUserSaplings] = useState([]);
-  const [configSaplings, setConfigSaplings] = useState({});
+  const initialUserSaplings = window.sessionStorage.getItem('USER_SAPLINGS');
+  const initialConfigSaplings = window.sessionStorage.getItem(
+    'CONFIG_SAPLINGS'
+  );
+
+  const [userSaplings, setUserSaplings] = useState(
+    initialUserSaplings ? JSON.parse(initialUserSaplings) : []
+  );
+  const [configSaplings, setConfigSaplings] = useState(
+    initialConfigSaplings ? JSON.parse(initialConfigSaplings) : []
+  );
 
   const sessionUser = window.sessionStorage.getItem('CANOPY_USER');
   const [user, setUser] = useState(
@@ -99,6 +108,10 @@ export function CanopyProvider({
     fetchConfigSaplings(saplingURL).then(saplings => {
       mountConfigSaplings(saplings);
       mountConfigSaplingStyles(saplings);
+      window.sessionStorage.setItem(
+        'CONFIG_SAPLINGS',
+        JSON.stringify(saplings)
+      );
     });
   }, [saplingURL]);
 
@@ -116,6 +129,10 @@ export function CanopyProvider({
       fetchUserSaplings(saplingURL).then(saplings => {
         mountCurrentSapling(saplings);
         setUserSaplings(saplings);
+        window.sessionStorage.setItem(
+          'USER_SAPLINGS',
+          JSON.stringify(saplings)
+        );
       });
     } else {
       window.$CANOPY.hideCanopy();


### PR DESCRIPTION
Fixes an issue in Canopy UIs that display saplings in nav tabs would disappear and then quickly reappear on refresh. This was because the sapling state was being initialized as an empty array on each page refresh.

This commit fixes the issue by caching the sapling state in session storage, so the state is initialized as the previously fetched value.

To test:

1. Open the package.json file for a UI using CanopyJS (such as the Grid UI or Splinter UI).
2. Replace the splinter-canopyjs dependency with this: `"github:dplumb94/splinter-canopyjs#no-refresh"`
3. Rebuild UI docker containers and start up the docker-compose file at `docker/docker-compose.yaml`
4. You should see that after the initial render, the sapling tabs do not disappear between page refreshes.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>