### PR TITLE
Check if sideNav is in dom before hiding it

### DIFF
--- a/src/CanopyContext.js
+++ b/src/CanopyContext.js
@@ -71,7 +71,9 @@ export function CanopyProvider({
 
   window.$CANOPY.hideCanopy = () => {
     const sideNavElement = document.getElementById('root');
-    sideNavElement.classList.add('display-none');
+    if (sideNavElement) {
+      sideNavElement.classList.add('display-none');
+    }
   };
 
   window.$CANOPY.setUser = canopyUser => {


### PR DESCRIPTION
Have $CANOPY.hideCanopy check if the sideNav element is undefined or null
before attempting to hide it. This is to account for the possiblity that
a sapling has removed the sideNav element from the DOM.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>