### PR TITLE
Unmount user sapling styles when not rendered

### DIFF
--- a/src/CanopyContext.js
+++ b/src/CanopyContext.js
@@ -21,7 +21,7 @@ import { createBrowserHistory } from 'history';
 import { get } from './request';
 import {
   mountCurrentSapling,
-  mountSaplingStyles,
+  mountConfigSaplingStyles,
   mountConfigSaplings
 } from './loadSaplings';
 
@@ -98,7 +98,7 @@ export function CanopyProvider({
 
     fetchConfigSaplings(saplingURL).then(saplings => {
       mountConfigSaplings(saplings);
-      mountSaplingStyles(saplings);
+      mountConfigSaplingStyles(saplings);
     });
   }, [saplingURL]);
 
@@ -114,7 +114,6 @@ export function CanopyProvider({
   useEffect(() => {
     if (sessionUser) {
       fetchUserSaplings(saplingURL).then(saplings => {
-        mountSaplingStyles(saplings);
         mountCurrentSapling(saplings);
         setUserSaplings(saplings);
       });

--- a/src/loadSaplings.js
+++ b/src/loadSaplings.js
@@ -15,7 +15,7 @@
  */
 
 import promiseLoader from './promiseLoader';
-import styleLoader from './styleLoader';
+import { styleLoader, unloadStylesByClassName } from './styleLoader';
 
 export async function mountCurrentSapling(userSaplingsResponse) {
   // Saplings will be guaranteed to to have a collision-free namespace that
@@ -37,18 +37,25 @@ export async function mountCurrentSapling(userSaplingsResponse) {
   );
 
   if (currentSaplingManifest) {
+    unloadStylesByClassName('user-sapling-stylesheet');
+    await Promise.all(
+      currentSaplingManifest.styleFiles.map(styleFile =>
+        styleLoader(`http://${styleFile}`, 'user-sapling-stylesheet')
+      )
+    );
     await Promise.all(
       currentSaplingManifest.runtimeFiles.map(saplingFile =>
         promiseLoader(`http://${saplingFile}`)
       )
     );
+
     return true;
   }
 
   return false;
 }
 
-export async function mountSaplingStyles(saplingResponse) {
+export async function mountConfigSaplingStyles(saplingResponse) {
   const saplingStyleFiles = saplingResponse
     .map(sapling => sapling.styleFiles)
     .flatMap(style => style)
@@ -59,7 +66,9 @@ export async function mountSaplingStyles(saplingResponse) {
   }
 
   await Promise.all(
-    saplingStyleFiles.map(styleFile => styleLoader(`http://${styleFile}`))
+    saplingStyleFiles.map(styleFile =>
+      styleLoader(`http://${styleFile}`, 'config-sapling-stylesheet')
+    )
   );
   return true;
 }

--- a/src/styleLoader.js
+++ b/src/styleLoader.js
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
-function styleLoader(styleUrl) {
+function unloadStylesByClassName(elementClassName) {
+  const stylesheetLinks = document.getElementsByClassName(elementClassName);
+  Array.from(stylesheetLinks).map(element => element.remove());
+}
+
+function styleLoader(styleUrl, isUserSaplingStyle) {
   const url = new URL(styleUrl);
   return new Promise((resolve, reject) => {
     const head = document.querySelector('head');
     const link = document.createElement('link');
+    if (isUserSaplingStyle) {
+      link.className = 'user-sapling-stylesheet';
+    }
     link.href = url;
     link.rel = 'stylesheet';
     link.onload = resolve;
@@ -27,4 +35,4 @@ function styleLoader(styleUrl) {
   });
 }
 
-export default styleLoader;
+export { unloadStylesByClassName, styleLoader };


### PR DESCRIPTION
Currently Canopy will load all of the sapling styles at once, for all
saplings. This is problematic because it leads to collisions in styles
between saplings.

This commit adds functionality to unmount styles for the previous user
sapling when a new user sapling is rendered.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>