### PR TITLE
Add logout

### DIFF
--- a/src/components/navigation/Logout.js
+++ b/src/components/navigation/Logout.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import Icon from '@material-ui/core/Icon';
+import { get } from '../../request';
+
+export const Logout = () => {
+  const onLogout = async () => {
+    if (window.sessionStorage.getItem('CANOPY_USER')) {
+      const { splinterURL } = window.$CANOPY.getSharedConfig().canopyConfig;
+      const { token } = JSON.parse(
+        window.sessionStorage.getItem('CANOPY_USER')
+      );
+
+      sessionStorage.removeItem('CANOPY_USER');
+      if (window.sessionStorage.getItem('CANOPY_KEYS')) {
+        window.sessionStorage.removeItem('CANOPY_KEYS');
+        if (window.sessionStorage.getItem('KEY_SECRET')) {
+          window.sessionStorage.removeItem('KEY_SECRET');
+        }
+      }
+
+      if (sessionStorage.getItem('LOGOUT')) {
+        try {
+          await get(
+            `${splinterURL}${window.sessionStorage.getItem('LOGOUT')}`,
+            request => {
+              request.setRequestHeader('Authorization', `Bearer ${token}`);
+            }
+          );
+          window.sessionStorage.removeItem('LOGOUT');
+          window.location.href = `${window.location.origin}/login`;
+        } catch (err) {
+          switch (err.status) {
+            case 401:
+              window.location.href = `${window.location.origin}/login`;
+              break;
+            default:
+              break;
+          }
+        }
+      } else {
+        window.location.href = `${window.location.origin}/login`;
+      }
+    } else {
+      window.location.href = `${window.location.origin}/login`;
+    }
+  };
+
+  return (
+    <button type="button" className="Logout" title="logout" onClick={onLogout}>
+      <div className="border">
+        <div className="icon">
+          <Icon>exit_to_app_icon</Icon>
+        </div>
+      </div>
+      <div className="label">Logout</div>
+    </button>
+  );
+};

--- a/src/components/navigation/SideNav.js
+++ b/src/components/navigation/SideNav.js
@@ -17,6 +17,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import Icon from '@material-ui/core/Icon';
+import { Logout } from './Logout';
 import { useUserSaplings } from '../../CanopyContext';
 
 import { NavItem } from './NavItem';
@@ -73,6 +74,7 @@ function ProfileTab() {
         </div>
       </div>
       <div className="label">Profile</div>
+      <Logout />
     </a>
   );
 }

--- a/src/components/navigation/SideNav.scss
+++ b/src/components/navigation/SideNav.scss
@@ -166,6 +166,19 @@
       }
     }
 
+    .Logout {
+      width: 0;
+      height: 0;
+      background: none;
+      overflow: hidden;
+      position: absolute;
+      border: unset;
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      text-decoration: none;
+    }
+
     .label {
       margin-top: 5px;
       font-size: 11px;
@@ -179,6 +192,31 @@
 
         .icon {
           color: var(--color-primary-light);
+        }
+      }
+      .Logout {
+        width: 75px;
+        height: 75px;
+        margin-bottom: 144px;
+        outline: none;
+
+        .border {
+          border: none;
+        }
+
+        .icon {
+          color: var(--color-primary);
+        }
+
+        &:hover {
+          .border {
+            border: 3px solid #999999;
+
+            .icon {
+              color: var(--color-primary-light);
+              cursor: pointer;
+            }
+          }
         }
       }
     }

--- a/src/request.js
+++ b/src/request.js
@@ -25,10 +25,13 @@ function errorResponse(request, message) {
   };
 }
 
-export function get(url) {
+export function get(url, headerFn = null) {
   return new Promise(resolve => {
     const request = new XMLHttpRequest();
     request.open('GET', url, true);
+    if (headerFn) {
+      headerFn(request);
+    }
     request.timeout = 5000;
 
     request.onload = () => {


### PR DESCRIPTION
This PR adds a logout button to the canopy sidebar, hovering over the profile button will expand a logout button. Clicking the logout button will make a call to the `/oauth/logout` endpoint, remove `CANOPY_USER`, `CANOPY_KEYS`, and `KEY_SECRET` from the session storage and return to the ui login screen.

### **Testing:**

modify the splinter-canopyjs dependency in the `package.json` in splinter-ui to point to this branch 
`"splinter-canopyjs": "github:isabeltomb/splinter-canopyjs#logout"`

(you may need to either delete your `splinter-ui` image in docker before building splinter-ui or build with `--no-cache` for the splinter-canopyjs dependency to be updated)

to build the splinter-ui with oauth login set the following environment variables:
```
OAUTH_CLIENT_ID=
OAUTH_CLIENT_SECRET=
OAUTH_PROVIDER=
OAUTH_OPENID_URL=
```
then run

`docker-compose -f docker-compose-oauth.yaml up --build`

to build splinter-ui with biome login run 

`docker-compose -f docker-compose-biome.yaml up --build`

navigate to http://localhost:3030 in a browser and register or login

to logout, hover over the profile button to expand the logout button

click the logout button and you should be returned to the login page and be able to log back into the ui
any keys that were added before logging out should still appear on the profile page after logging out and logging back in