### PR TITLE
Add custom icon support to sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/plugin-transform-runtime": "^7.8.3",
-    "@babel/preset-env": "^7.8.4",
+    "@babel/preset-env": "^7.8.7",
     "@babel/preset-react": "^7.8.3",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",

--- a/src/components/navigation/NavItem.js
+++ b/src/components/navigation/NavItem.js
@@ -20,7 +20,7 @@ import classnames from 'classnames';
 import Icon from '@material-ui/core/Icon';
 
 export const NavItem = props => {
-  const { path, logo, label } = props;
+  const { path, icon, label, logo } = props;
 
   const classes = classnames('nav-tab', {
     'page-active': path === `/${window.location.pathname.split('/')[1]}`
@@ -30,7 +30,11 @@ export const NavItem = props => {
     <a href={path} className={classes}>
       <div className="border">
         <div className="icon">
-          <Icon>{logo}</Icon>
+          {logo ? (
+            <img src={logo} className="brand-logo" alt={label} />
+          ) : (
+            <Icon>{icon}</Icon>
+          )}
         </div>
       </div>
       <div className="label">{label}</div>
@@ -38,8 +42,33 @@ export const NavItem = props => {
   );
 };
 
+const iconImagePropsCheck = (props, propName, componentName) => {
+  if (!props.icon && !props.logo) {
+    return new Error(
+      `One of 'logo' or 'icon' is required by '${componentName}' component`
+    );
+  }
+
+  if (
+    typeof props[propName] !== 'string' &&
+    typeof props[propName] !== 'undefined'
+  ) {
+    return new Error(
+      `Invalid prop '${propName}' passed to '${componentName}': must be a string`
+    );
+  }
+
+  return true;
+};
+
 NavItem.propTypes = {
+  icon: iconImagePropsCheck,
   label: PropTypes.string.isRequired,
-  logo: PropTypes.string.isRequired,
+  logo: iconImagePropsCheck,
   path: PropTypes.string.isRequired
+};
+
+NavItem.defaultProps = {
+  icon: undefined,
+  logo: undefined
 };

--- a/src/components/navigation/SideNav.js
+++ b/src/components/navigation/SideNav.js
@@ -25,16 +25,23 @@ import { NavItem } from './NavItem';
 export const SideNav = () => {
   const makeUserSaplingTabs = userSaplings =>
     userSaplings
-      .map(({ displayName, namespace, icon }) => {
+      .map(({ displayName, namespace, icon, logo }) => {
         return {
           path: `/${namespace}`,
           displayName,
-          logo: icon
+          icon,
+          logo
         };
       })
-      .map(({ path, displayName, logo }) => {
+      .map(({ path, displayName, icon, logo }) => {
         return (
-          <NavItem key={path} path={path} label={displayName} logo={logo} />
+          <NavItem
+            key={path}
+            path={path}
+            label={displayName}
+            icon={icon}
+            logo={logo}
+          />
         );
       });
 
@@ -48,7 +55,7 @@ export const SideNav = () => {
         <div className="nav-tab">
           <div className="border">
             <div className="icon">
-              <Icon eco_icon>eco_icon</Icon>
+              <Icon>eco_icon</Icon>
             </div>
           </div>
           <div className="label">Saplings</div>

--- a/src/components/navigation/SideNav.scss
+++ b/src/components/navigation/SideNav.scss
@@ -87,6 +87,15 @@
         border-radius: 10px;
         outline: none;
         transition: $transitionDuration-s;
+
+        .brand-logo {
+          width: 1em;
+          height: 1em;
+          overflow: hidden;
+          font-size: 1.5rem;
+          flex-shrink: 0;
+          user-select: none;
+        }
       }
     }
 


### PR DESCRIPTION
This adds support for custom icons for a sapling in the sidebar. These
custom icons are specified by setting the `logo` field in a sapling's
entry in the sapling manifest with a URL to the image. The custom image
takes precedence over an icon set with the `icon` field but at least one
of these fields is required.

Signed-off-by: Davey Newhall <newhall@bitwise.io>