### PR TITLE
Remove Sapling nav tab

### DIFF
--- a/src/components/navigation/SideNav.js
+++ b/src/components/navigation/SideNav.js
@@ -50,17 +50,7 @@ export const SideNav = () => {
       <a href="/" className="brand">
         <div />
       </a>
-      <div className="nav-items">
-        {makeUserSaplingTabs(useUserSaplings())}
-        <div className="nav-tab">
-          <div className="border">
-            <div className="icon">
-              <Icon>eco_icon</Icon>
-            </div>
-          </div>
-          <div className="label">Saplings</div>
-        </div>
-      </div>
+      <div className="nav-items">{makeUserSaplingTabs(useUserSaplings())}</div>
       <div className="canopy-items">
         <ProfileTab />
       </div>


### PR DESCRIPTION
Currently this button doesn't do anything. It should be removed until
there is some Sapling selector functionality that would use it.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>